### PR TITLE
handle too many requests to igdb

### DIFF
--- a/update_db.py
+++ b/update_db.py
@@ -3,6 +3,7 @@ import argparse
 import pathlib
 import json
 import os
+import time
 
 # lib imports
 import requests
@@ -219,10 +220,16 @@ def get_data():
         full_dict[end_point] = dict()
 
         while result:
-            byte_array = wrapper.api_request(
-                endpoint=end_point,
-                query=f'fields {", ".join(end_point_dict["fields"])}; limit {limit}; offset {offset};'
-            )
+            try:
+                byte_array = wrapper.api_request(
+                    endpoint=end_point,
+                    query=f'fields {", ".join(end_point_dict["fields"])}; limit {limit}; offset {offset};'
+                )
+            except requests.exceptions.HTTPError:
+                # handle too many requests
+                time.sleep(1)
+                continue
+
             json_result = json.loads(byte_array)  # this is a list of dictionaries
             # items.extend(json_result)
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
IGDB allows 4 requests per second to their api. Sometimes, the workflow hits this limit, but not consistently. This PR should prevent the workflow from failing. It will now wait 1 second before trying the request again.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
